### PR TITLE
Sidebar collapsed by default

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -66,6 +66,9 @@ const config: DocsThemeConfig = {
         <main {...props} />
       </>
     )
+  },
+  sidebar: {
+    defaultMenuCollapseLevel: 1
   }
 }
 


### PR DESCRIPTION
Followed steps from Nextra Docs: https://nextra.site/docs/docs-theme/theme-configuration#menu-collapse-level

> Menu Collapse Level
> 
> By default, the sidebar menu is collapsed at level 2. You can change it by setting sidebar.defaultMenuCollapseLevel to a different number. For example, when set to 1, every folder will be collapsed by default and when set to Infinity, all nested folders will be expanded by default.
> If sidebar.autoCollapse is set to true, then all folders that do not contain an active/focused route will automatically collapse up to the level set by sidebar.defaultMenuCollapseLevel. e.g. if defaultMenuCollapseLevel is 2, then top-level folders will not auto-collapse.