### PR TITLE
Add 'Anti-Malware Codes:' prefix to sidebar link to their page

### DIFF
--- a/pages/verifiability/_meta.json
+++ b/pages/verifiability/_meta.json
@@ -4,7 +4,7 @@
   "detecting-malware": "Detecting Malware",
   "zero-knowledge": "Zero Knowledge Proofs",
   "rla": "Risk Limiting Audits",
-  "proving-confirmation": "Proving Voter Confirmation",
+  "proving-confirmation": "Anti-Malware Codes: Proving Verification",
   "remediating-compromised-votes": "Remediating Compromised Votes",
   "print-ballots": "Paper Trail",
   "privacy-protectors": "Privacy Protectors",


### PR DESCRIPTION
It's currently a bit hard to find the page talking about "Anti-Malware Codes".

So this is a proposed change to the sidebar Table of Contents:

<img width="298" alt="image" src="https://github.com/dsernst/siv-docs/assets/6340841/8b7fd4fa-797b-443b-b4d0-dd73103d4775">

The page itself hasn't changed, it's still https://docs.siv.org/verifiability/proving-confirmation